### PR TITLE
not open bolt modal if the user clicks on apple pay button

### DIFF
--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltModalConfigure.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltModalConfigure.js
@@ -17,7 +17,7 @@ $(document).ready(function () {
             var createBoltOrderUrl = $('.create-bolt-order-url').val();
 
             // add an event handler to Bolt button's click
-            checkoutBoltButton.click(function () {
+            checkoutBoltButton.click(function (e) {
                 // call backend to create cart in Bolt
                 $.ajax({
                     url: createBoltOrderUrl,
@@ -30,7 +30,10 @@ $(document).ready(function () {
                             };
 
                             var boltButtonApp = BoltCheckout.configure(cart, data.hints, null); // eslint-disable-line no-undef
-                            boltButtonApp.open();
+                            // don't open bolt modal for apple pay
+                            if ($(e.target).attr('data-tid') !== 'apple-pay-button') {
+                                boltButtonApp.open();
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
asana: https://app.asana.com/0/1201931884901947/1202973257261391

Currently the bolt modal opens even if the user clicks on the apple pay button. That's because the apple pay button is a child element of the` instant-bolt-checkout-button` div. This PR is to run applepay's own logic 