### PR TITLE
rename auth code

### DIFF
--- a/metadata/bolt-meta-import/meta/system-objecttype-extensions.xml
+++ b/metadata/bolt-meta-import/meta/system-objecttype-extensions.xml
@@ -365,7 +365,7 @@
         <externally-managed-flag>false</externally-managed-flag>
         <min-length>0</min-length>
       </attribute-definition>
-      <attribute-definition attribute-id="boltCreditCardAuthCode">
+      <attribute-definition attribute-id="bankAuthorizationCode">
         <display-name xml:lang="x-default">Credit Card Auth Code</display-name>
         <type>string</type>
         <mandatory-flag>false</mandatory-flag>


### PR DESCRIPTION
FP is using `TransactionPropertyKeyBankAuthCode` for auth code so we rename to fit that name. context: https://github.com/BoltApp/source/pull/44268 