### PR TITLE
Bugfix: Js error on cart page

### DIFF
--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -97,7 +97,7 @@ exports.resetBoltMiniCartConfigure = function () {
 
 exports.initBoltButton = function () {
     var boltButtonExist = setInterval(function () {
-        var checkoutBoltButton = $('.bolt-cart[data-tid="instant-bolt-checkout-button"]'); // @ts-ignore
+        var checkoutBoltButton = $('.bolt-cart-btn[data-tid="instant-bolt-checkout-button"]'); // @ts-ignore
         // have to check if child of this dom is svg, otherwise bolt button is not fully rendered (it's the object)
         var boltButtonLoaded = checkoutBoltButton && window.BoltCheckout && checkoutBoltButton.children()[0].nodeName === 'svg';
         if (boltButtonLoaded) {
@@ -112,7 +112,7 @@ exports.initBoltButton = function () {
 exports.initBoltMiniCartButton = function () {
     $('.minicart-footer').spinner().start();
     var boltButtonExist = setInterval(function () {
-        var checkoutBoltButton = $('.bolt-minicart[data-tid="instant-bolt-checkout-button"]'); // @ts-ignore
+        var checkoutBoltButton = $('.bolt-minicart-btn[data-tid="instant-bolt-checkout-button"]'); // @ts-ignore
         var boltButtonLoaded = checkoutBoltButton && window.BoltCheckout;
         if (boltButtonLoaded) {
             clearInterval(boltButtonExist);


### PR DESCRIPTION
https://app.asana.com/0/632578947811321/1204429290751019/f

The Issue: The css selector ".bolt-minicart[data-tid="instant-bolt-checkout-button"]" and ".bolt-cart[data-tid="instant-bolt-checkout-button"]" do not exist, therefore, the function is repeatedly called and throws an exception "nnot read properties of undefined (reading 'nodeName')" each time

Expected Behavior / Proposed Fix:  
There shouldn't be any js error

Steps to recreate: 

- Add any item to your cart
- Go to cart page
- Open the console, you will see the js error

![image](https://user-images.githubusercontent.com/3198527/233003918-2a7d779b-72ea-43dc-89d6-87e3642b397e.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204426696112069