### PR TITLE
Bugfix: fail to import bootstrap/scss/functions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,10 @@ module.exports = [{
                     loader: 'sass-loader',
                     options: {
                         includePaths: [
+                            path.resolve(
+                                process.cwd(),
+                                '../storefront-reference-architecture/node_modules/'
+                            ),
                             path.resolve('node_modules')
                         ]
                     }


### PR DESCRIPTION
https://app.asana.com/0/1201931884901947/1204478442532101/f

If the cartridge contains any scss file which tries to import bootstrap lib file, the building process would trigger an error "File to import not found or unreadable: bootstrap/xxxx"

eg.

![image](https://user-images.githubusercontent.com/3198527/234573744-4497c837-bbde-4176-b2da-a3c693ea2d1a.png)
