### PR TITLE
Use order token for validation

### DIFF
--- a/cartridges/int_bolt_sfra/cartridge/controllers/Login.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Login.js
@@ -27,13 +27,13 @@ server.get('OAuthRedirectBolt', function (req, res, next) {
     order_id: Bolt order ID
     */ 
     var boltParam = request.getHttpParameterMap();
-    var { code, scope, state, reference, display_id: displayId, order_uuid: orderUUID, order_id: boltOrderId} = boltParam;
+    var { code, scope, state, reference, display_id: displayId, order_uuid: orderToken, order_id: boltOrderId} = boltParam;
     if (!code.value || !scope.value || !state.value) {
         log.error('Missing required parameter in request form: ' + LogUtils.maskCustomerData(req));
         return renderError(res, next);
     }
 
-    var output = OAuthUtils.oauthLoginOrCreatePlatformAccount(code, scope, displayId, orderUUID);
+    var output = OAuthUtils.oauthLoginOrCreatePlatformAccount(code, scope, displayId, orderToken);
     if (output.status === 'failure') {
         if (output.ignoreError) { // if ignore error, don't show error page.
             return next();


### PR DESCRIPTION
Order UUID is not available for OCAPI submit order call, so use the order token instead to validate the order.
