### PR TITLE
Fix SSO order confirmation redirect

### DIFF
--- a/cartridges/int_bolt_sfra/cartridge/controllers/Account.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Account.js
@@ -17,6 +17,7 @@ server.prepend('Show', function (req, res, next) {
     var boltOrderId = req.session.privacyCache.store.boltOrderId;
     if (boltOrderId) {
         putSFCCObject(boltOrderId);
+        req.session.privacyCache.store.boltOrderId = '';
     }
 
     return next();

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var server = require('server');
+var Order = module.superModule;
+server.extend(Order);
+
+var Resource = require('dw/web/Resource');
+var URLUtils = require('dw/web/URLUtils');
+var Site = require('dw/system/Site');
+var OrderMgr = require('dw/order/OrderMgr');
+var Locale = require('dw/util/Locale');
+
+var csrfProtection = require('*/cartridge/scripts/middleware/csrf');
+var reportingUrlsHelper = require('*/cartridge/scripts/reportingUrls');
+var OrderModel = require('*/cartridge/models/order');
+var userLoggedIn = require('*/cartridge/scripts/middleware/userLoggedIn');
+var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
+
+/**
+ * Exclude order customer ID check for Bolt SSO, since order is assigned to new created account 
+ * if shopper creates account during checkout.
+ */
+server.replace('Confirm',
+    consentTracking.consent,
+    server.middleware.https,
+    csrfProtection.generateToken,
+    function (req, res, next) {    
+    var order;
+    var boltEnableSSO = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
+
+    if (!req.form.orderToken || !req.form.orderID) {
+        res.render('/error', {
+            message: Resource.msg('error.confirmation.error', 'confirmation', null)
+        });
+        return next();
+    }
+
+    order = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
+
+    if (!order || (!boltEnableSSO && order.customer.ID !== req.currentCustomer.raw.ID)) {
+        res.render('/error', {
+            message: Resource.msg('error.confirmation.error', 'confirmation', null)
+        });
+
+        return next();
+    }
+    var lastOrderID = Object.prototype.hasOwnProperty.call(req.session.raw.custom, 'orderID') ? req.session.raw.custom.orderID : null;
+    if (lastOrderID === req.querystring.ID) {
+        res.redirect(URLUtils.url('Home-Show'));
+        return next();
+    }
+
+    var config = {
+        numberOfLineItems: '*'
+    };
+
+    var currentLocale = Locale.getLocale(req.locale.id);
+
+    var orderModel = new OrderModel(
+        order,
+        { config: config, countryCode: currentLocale.country, containerView: 'order' }
+    );
+    var passwordForm;
+
+    var reportingURLs = reportingUrlsHelper.getOrderReportingURLs(order);
+
+    if (!req.currentCustomer.profile) {
+        passwordForm = server.forms.getForm('newPasswords');
+        passwordForm.clear();
+        res.render('checkout/confirmation/confirmation', {
+            order: orderModel,
+            returningCustomer: false,
+            passwordForm: passwordForm,
+            reportingURLs: reportingURLs,
+            orderUUID: order.getUUID()
+        });
+    } else {
+        res.render('checkout/confirmation/confirmation', {
+            order: orderModel,
+            returningCustomer: true,
+            reportingURLs: reportingURLs,
+            orderUUID: order.getUUID()
+        });
+    }
+    req.session.raw.custom.orderID = req.querystring.ID; // eslint-disable-line no-param-reassign
+    return next();
+});
+
+module.exports = server.exports();

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
@@ -15,10 +15,6 @@ var reportingUrlsHelper = require('*/cartridge/scripts/reportingUrls');
 var OrderModel = require('*/cartridge/models/order');
 var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
 
-/**
- * Exclude order customer ID check for Bolt SSO, since order is assigned to new created account
- * if shopper creates account during checkout.
- */
 server.replace(
     'Confirm',
     consentTracking.consent,
@@ -38,8 +34,8 @@ server.replace(
         order = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
 
         // This is where different from the base cartridge, skip order customer check for SSO.
-        // If shopper check the checkbox to create an account during checkout, we set the order to the new created account but not login, so order customer id
-        // is different from the guest customer ID in the original request.
+        // If shopper check the checkbox to create an account during checkout, we set the order to the new created account but not login,
+        // so the order customer id is different from the guest customer ID in the original request.
         if (!order || (!boltEnableSSO && order.customer.ID !== req.currentCustomer.raw.ID)) {
             res.render('/error', {
                 message: Resource.msg('error.confirmation.error', 'confirmation', null)

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Order.js
@@ -13,77 +13,81 @@ var Locale = require('dw/util/Locale');
 var csrfProtection = require('*/cartridge/scripts/middleware/csrf');
 var reportingUrlsHelper = require('*/cartridge/scripts/reportingUrls');
 var OrderModel = require('*/cartridge/models/order');
-var userLoggedIn = require('*/cartridge/scripts/middleware/userLoggedIn');
 var consentTracking = require('*/cartridge/scripts/middleware/consentTracking');
 
 /**
- * Exclude order customer ID check for Bolt SSO, since order is assigned to new created account 
+ * Exclude order customer ID check for Bolt SSO, since order is assigned to new created account
  * if shopper creates account during checkout.
  */
-server.replace('Confirm',
+server.replace(
+    'Confirm',
     consentTracking.consent,
     server.middleware.https,
     csrfProtection.generateToken,
-    function (req, res, next) {    
-    var order;
-    var boltEnableSSO = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
+    function (req, res, next) {
+        var order;
+        var boltEnableSSO = Site.getCurrent().getCustomPreferenceValue('boltEnableSSO');
 
-    if (!req.form.orderToken || !req.form.orderID) {
-        res.render('/error', {
-            message: Resource.msg('error.confirmation.error', 'confirmation', null)
-        });
+        if (!req.form.orderToken || !req.form.orderID) {
+            res.render('/error', {
+                message: Resource.msg('error.confirmation.error', 'confirmation', null)
+            });
+            return next();
+        }
+
+        order = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
+
+        // This is where different from the base cartridge, skip order customer check for SSO.
+        // If shopper check the checkbox to create an account during checkout, we set the order to the new created account but not login, so order customer id
+        // is different from the guest customer ID in the original request.
+        if (!order || (!boltEnableSSO && order.customer.ID !== req.currentCustomer.raw.ID)) {
+            res.render('/error', {
+                message: Resource.msg('error.confirmation.error', 'confirmation', null)
+            });
+
+            return next();
+        }
+        var lastOrderID = Object.prototype.hasOwnProperty.call(req.session.raw.custom, 'orderID') ? req.session.raw.custom.orderID : null;
+        if (lastOrderID === req.querystring.ID) {
+            res.redirect(URLUtils.url('Home-Show'));
+            return next();
+        }
+
+        var config = {
+            numberOfLineItems: '*'
+        };
+
+        var currentLocale = Locale.getLocale(req.locale.id);
+
+        var orderModel = new OrderModel(
+            order,
+            { config: config, countryCode: currentLocale.country, containerView: 'order' }
+        );
+        var passwordForm;
+
+        var reportingURLs = reportingUrlsHelper.getOrderReportingURLs(order);
+
+        if (!req.currentCustomer.profile) {
+            passwordForm = server.forms.getForm('newPasswords');
+            passwordForm.clear();
+            res.render('checkout/confirmation/confirmation', {
+                order: orderModel,
+                returningCustomer: false,
+                passwordForm: passwordForm,
+                reportingURLs: reportingURLs,
+                orderUUID: order.getUUID()
+            });
+        } else {
+            res.render('checkout/confirmation/confirmation', {
+                order: orderModel,
+                returningCustomer: true,
+                reportingURLs: reportingURLs,
+                orderUUID: order.getUUID()
+            });
+        }
+        req.session.raw.custom.orderID = req.querystring.ID; // eslint-disable-line no-param-reassign
         return next();
     }
-
-    order = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
-
-    if (!order || (!boltEnableSSO && order.customer.ID !== req.currentCustomer.raw.ID)) {
-        res.render('/error', {
-            message: Resource.msg('error.confirmation.error', 'confirmation', null)
-        });
-
-        return next();
-    }
-    var lastOrderID = Object.prototype.hasOwnProperty.call(req.session.raw.custom, 'orderID') ? req.session.raw.custom.orderID : null;
-    if (lastOrderID === req.querystring.ID) {
-        res.redirect(URLUtils.url('Home-Show'));
-        return next();
-    }
-
-    var config = {
-        numberOfLineItems: '*'
-    };
-
-    var currentLocale = Locale.getLocale(req.locale.id);
-
-    var orderModel = new OrderModel(
-        order,
-        { config: config, countryCode: currentLocale.country, containerView: 'order' }
-    );
-    var passwordForm;
-
-    var reportingURLs = reportingUrlsHelper.getOrderReportingURLs(order);
-
-    if (!req.currentCustomer.profile) {
-        passwordForm = server.forms.getForm('newPasswords');
-        passwordForm.clear();
-        res.render('checkout/confirmation/confirmation', {
-            order: orderModel,
-            returningCustomer: false,
-            passwordForm: passwordForm,
-            reportingURLs: reportingURLs,
-            orderUUID: order.getUUID()
-        });
-    } else {
-        res.render('checkout/confirmation/confirmation', {
-            order: orderModel,
-            returningCustomer: true,
-            reportingURLs: reportingURLs,
-            orderUUID: order.getUUID()
-        });
-    }
-    req.session.raw.custom.orderID = req.querystring.ID; // eslint-disable-line no-param-reassign
-    return next();
-});
+);
 
 module.exports = server.exports();


### PR DESCRIPTION
For guest shoppers that check the checkbox to create an account during checkout. We create a Bolt account and SFCC account for them, and assign this order to the created SFCC account, but not log in. So order customer is different from `req.currentCustomer.raw.ID` which fails the order confirmation redirect. This overwrites the base cartridge Order-Confirm to skip the order customer check, it's optional for merchants to do order reassign.