### PR TITLE
Replace login/logout buttons on SFRA

### DIFF
--- a/cartridges/int_bolt_custom/cartridge/templates/default/account/components/navTabs.isml
+++ b/cartridges/int_bolt_custom/cartridge/templates/default/account/components/navTabs.isml
@@ -1,0 +1,52 @@
+<ul class="nav nav-tabs nav-fill" role="tablist">
+    <li class="nav-item" role="presentation">
+        <iscomment>Bolt SSO change. Replace login button</iscomment>
+        <isif condition="${pdict.config.boltEnableSSO}">
+            <a
+                <isif condition="${pdict.navTabValue === 'login'}">
+                    class="nav-link active bolt-sso-custom"
+                <iselse>
+                    class="nav-link bolt-sso-custom"
+                </isif>
+                data-logged-in="false"
+                href="#login" data-toggle="tab" role="tab" aria-controls="login" aria-selected="true" id="login-tab">
+                ${Resource.msg('link.header.login.module', 'login', null)}
+            </a>
+        <iselse>
+            <a
+                <isif condition="${pdict.navTabValue === 'login'}">
+                    class="nav-link active"
+                <iselse>
+                    class="nav-link"
+                </isif>
+                href="#login" data-toggle="tab" role="tab" aria-controls="login" aria-selected="true" id="login-tab">
+                ${Resource.msg('link.header.login.module', 'login', null)}
+            </a>
+         </isif>
+    </li>
+    <li class="nav-item" role="presentation">
+        <iscomment>Bolt SSO change. Replace register button</iscomment>
+        <isif condition="${pdict.config.boltEnableSSO}">
+            <a
+                <isif condition="${pdict.navTabValue === 'register'}">
+                    class="nav-link active bolt-sso-custom"
+                <iselse>
+                    class="nav-link bolt-sso-custom"
+                </isif>
+                href="#register" data-toggle="tab" role="tab" aria-controls="register" aria-selected="false" id="register-tab">
+                ${Resource.msg('link.header.register.module', 'login', null)}
+            </a>
+        <iselse>
+            <a
+                <isif condition="${pdict.navTabValue === 'register'}">
+                    class="nav-link active"
+                <iselse>
+                    class="nav-link"
+                </isif>
+                data-logged-in="false"
+                href="#register" data-toggle="tab" role="tab" aria-controls="register" aria-selected="false" id="register-tab">
+                ${Resource.msg('link.header.register.module', 'login', null)}
+            </a>
+        </isif>
+    </li>
+</ul>

--- a/cartridges/int_bolt_custom/cartridge/templates/default/account/header.isml
+++ b/cartridges/int_bolt_custom/cartridge/templates/default/account/header.isml
@@ -1,0 +1,33 @@
+<isif condition="${pdict.name === null}">
+    <iscomment>Bolt SSO change. Replace login button</iscomment>
+    <div class="user hidden-md-down">
+        <isif condition="${pdict.config.boltEnableSSO}">
+            <a class="bolt-sso-custom" data-logged-in="false" href="${URLUtils.https('Login-Show')}" role="button" aria-label="${Resource.msg('label.header.loginbutton', 'account', null)}">
+        <iselse>
+            <a href="${URLUtils.https('Login-Show')}" role="button" aria-label="${Resource.msg('label.header.loginbutton', 'account', null)}">
+        </isif>
+            <i class="fa fa-sign-in" aria-hidden="true"></i>
+            <span class="user-message">${Resource.msg('link.header.login', 'account', null)}</span>
+        </a>
+    </div>
+<iselse/>
+    <div class="user hidden-md-down nav-item">
+        <a href="${'#'}" id="myaccount" aria-haspopup="true" aria-label="${Resource.msg('link.header.myaccount', 'account', null)}" role="button">
+            <i class="fa fa-sign-in" aria-hidden="true"></i><span class="user-message btn dropdown-toggle">${pdict.name}</span>
+        </a>
+        <div class="popover popover-bottom">
+            <ul class="nav" role="menu" aria-label="${Resource.msg('label.profile.myaccountlink', 'account', null)}" aria-hidden="true">
+                <li class="nav-item" role="presentation"><a href="${URLUtils.https('Account-Show')}" role="menuitem" tabindex="0">${Resource.msg('link.header.myaccount', 'account', null)}</a></li>
+                <li class="nav-item" role="presentation"><a href="${URLUtils.url('Order-History')}" role="menuitem" tabindex="0">${Resource.msg('label.myorders', 'account', null)}</a></li>
+                <li class="nav-item" role="presentation">
+                    <iscomment>Bolt SSO change. Replace logout button</iscomment>
+                    <isif condition="${pdict.config.boltEnableSSO}">
+                        <a class="bolt-sso-custom" data-logged-in="true" href="${URLUtils.url('Login-Logout')}" role="menuitem" tabindex="0">${Resource.msg('link.header.logout', 'account', null)}</a>
+                    <iselse>
+                        <a href="${URLUtils.url('Login-Logout')}" role="menuitem" tabindex="0">${Resource.msg('link.header.logout', 'account', null)}</a>
+                    </isif>
+                </li>
+            </ul>
+        </div>
+    </div>
+</isif>

--- a/cartridges/int_bolt_custom/cartridge/templates/default/account/login.isml
+++ b/cartridges/int_bolt_custom/cartridge/templates/default/account/login.isml
@@ -1,0 +1,44 @@
+<isdecorate template="common/layout/page">
+    <isscript>
+        var assets = require('*/cartridge/scripts/assets.js');
+        assets.addCss('/css/login.css');
+        assets.addJs('/js/login.js');
+    </isscript>
+
+    <div class="hero slant-down login-banner">
+        <h1 class="page-title">${Resource.msg('header.hero.image.login', 'login', null)}</h1>
+    </div>
+    <div class="container login-page">
+        <!---Breadcrumbs--->
+        <isinclude template="components/breadcrumbs/pageBreadcrumbs"/>
+        <div class="row justify-content-center equal-height">
+            <div class="col-sm-8 col-md-6">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="login-form-nav">
+                            <isinclude template="account/components/navTabs" />
+                            <iscomment>Bolt SSO change. Hide login and register form if SSO is enabled</iscomment>
+                            <isif condition="${!pdict.config.boltEnableSSO}">
+                                <div class="tab-content">
+                                    <div class="tab-pane ${pdict.navTabValue === 'login' ? 'active' : ''}" id="login" role="tabpanel" aria-labelledby="login-tab">
+                                        <isinclude template="account/components/loginForm" />
+                                        <isinclude template="account/password/requestPasswordResetModal"/>
+                                        <isinclude template="account/components/oauth" />
+                                    </div>
+                                    <div class="tab-pane ${pdict.navTabValue === "register" ? 'active' : ''}" id="register" role="tabpanel" aria-labelledby="register-tab">
+                                        <isinclude template="account/components/registerForm" />
+                                    </div>
+                                </div>
+                            </isif>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-8 col-md-6">
+                <div class="card">
+                    <isinclude template="account/components/trackOrderForm" />
+                </div>
+            </div>
+        </div>
+    </div>
+</isdecorate>

--- a/cartridges/int_bolt_custom/cartridge/templates/default/account/mobileHeader.isml
+++ b/cartridges/int_bolt_custom/cartridge/templates/default/account/mobileHeader.isml
@@ -1,0 +1,36 @@
+<isif condition="${pdict.name === null}">
+    <li class="nav-item d-lg-none" role="menuitem">
+        <iscomment>Bolt SSO change. Replace login button</iscomment>
+        <isif condition="${pdict.config.boltEnableSSO}">
+            <a href="${URLUtils.https('Login-Show')}" class="nav-link bolt-sso-custom" data-logged-in="false">
+        <iselse>
+            <a href="${URLUtils.https('Login-Show')}" class="nav-link">
+        </isif>
+            <i class="fa fa-sign-in" aria-hidden="true"></i>
+            <span class="user-message">${Resource.msg('link.header.login', 'account', null)}</span>
+        </a>
+    </li>
+<iselse/>
+    <li class="nav-item d-lg-none dropdown" role="menuitem">
+        <span class="nav-link dropdown-toggle" role="button" data-toggle="dropdown">
+            <i class="fa fa-sign-in" aria-hidden="true"></i>
+            <span class="user-message">${pdict.name}</span>
+        </span>
+        <ul class="dropdown-menu" role="menu" aria-hidden="true">
+            <li class="dropdown-item" role="menuitem">
+                <a href="${URLUtils.https('Account-Show')}" class="dropdown-link" role="button">${Resource.msg('link.header.myaccount', 'account', null)}</a>
+            </li>
+            <li class="dropdown-item" role="menuitem">
+                <a href="${URLUtils.url('Order-History')}" class="dropdown-link" role="button">${Resource.msg('label.myorders', 'account', null)}</a>
+            </li>
+            <li class="dropdown-item" role="menuitem">
+                <iscomment>Bolt SSO change. Replace logout button</iscomment>
+                <isif condition="${pdict.config.boltEnableSSO}">
+                    <a href="${URLUtils.url('Login-Logout')}" class="dropdown-link bolt-sso-custom" data-logged-in="true" role="button">${Resource.msg('link.header.logout', 'account', null)}</a>
+                <iselse>
+                    <a href="${URLUtils.url('Login-Logout')}" class="dropdown-link" role="button">${Resource.msg('link.header.logout', 'account', null)}</a>
+                </isif>
+            </li>
+        </ul>
+    </li>
+</isif>

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/main.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/main.js
@@ -13,6 +13,7 @@ $(document).ready(function () {
     processInclude(require('base/components/clientSideValidation'));
     processInclude(require('base/components/countrySelector'));
     processInclude(require('base/components/toolTip'));
+    processInclude(require('./sso'));
 });
 
 require('base/thirdParty/bootstrap');

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/sso.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/sso.js
@@ -1,0 +1,7 @@
+'use strict';
+
+$(document).ready(function () {
+    $('.bolt-sso-custom').on('click', function (e) {
+        e.preventDefault(); // prevent URL redirection
+    });
+});

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Account.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Account.js
@@ -12,6 +12,9 @@ var BoltHttpUtils = require('int_bolt_core/cartridge/scripts/services/utils/http
 var LogUtils = require('int_bolt_core/cartridge/scripts/utils/boltLogUtils');
 var log = LogUtils.getLogger('Login');
 
+var BoltPreferences = require('int_bolt_core/cartridge/scripts/services/utils/preferences');
+var configuration = BoltPreferences.getSitePreferences();
+
 // for SSO login during checkout, update dwsid in Bolt db.
 server.prepend('Show', function (req, res, next) {
     var boltOrderId = req.session.privacyCache.store.boltOrderId;
@@ -45,5 +48,12 @@ function putSFCCObject(boltOrderId) {
         log.error('Failed to update dwsid to Bolt');
     }
 }
+
+server.append('Header', function (req, res, next) {
+    res.setViewData({
+        config: configuration
+    });
+    next();
+});
 
 module.exports = server.exports();

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Login.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Login.js
@@ -14,6 +14,9 @@ var LogUtils = require('int_bolt_core/cartridge/scripts/utils/boltLogUtils');
 var OAuthUtils = require('int_bolt_core/cartridge/scripts/utils/oauthUtils');
 var log = LogUtils.getLogger('Login');
 
+var BoltPreferences = require('int_bolt_core/cartridge/scripts/services/utils/preferences');
+var configuration = BoltPreferences.getSitePreferences();
+
 server.get('OAuthRedirectBolt', function (req, res, next) {
     if (!Site.getCurrent().getCustomPreferenceValue('boltEnableSSO')) {
         log.error('Bolt SSO feature is not enabled');
@@ -75,5 +78,12 @@ function renderError(res, next) {
     });
     return next();
 }
+
+server.append('Show', function (req, res, next) {
+    res.setViewData({
+        config: configuration
+    });
+    next();
+});
 
 module.exports = server.exports();

--- a/cartridges/int_bolt_sfra/cartridge/templates/default/common/boltScripts.isml
+++ b/cartridges/int_bolt_sfra/cartridge/templates/default/common/boltScripts.isml
@@ -5,14 +5,5 @@
 <isif condition="${boltConfig.boltEnable}">
     <script id="bolt-track" src="${boltConfig.boltCdnUrl}/track.js" data-publishable-key="${boltConfig.boltMultiPublishableKey}"></script>
     <script id="bolt-connect" src="${boltConfig.boltCdnUrl}/connect.js" data-publishable-key="${boltConfig.boltMultiPublishableKey}"></script>
-</isif>
-
-<iscomment> SSO login and logout button </iscomment>
-<isif condition="${boltConfig.boltEnableSSO}">
-    <div class="bolt-account-sso" data-logged-in="false" />
-    <div class="bolt-account-sso" data-logged-in="true" />
-    <script id="bolt-account"
-        src="${boltConfig.boltAccountURL}/account.js" 
-        data-publishable-key="${boltConfig.boltMultiPublishableKey}">
-    </script>
+    <script id="bolt-account" src="${boltConfig.boltAccountURL}/account.js" data-publishable-key="${boltConfig.boltMultiPublishableKey}"></script>
 </isif>


### PR DESCRIPTION
To make our SSO button aligned with SFRA OOTB stylings(merchants can use this for reference), here are the changes:

1. remove the static Bolt login/logout buttons in `boltScript.isml` 
2. add `class="bolt-sso-custom"` and `data-logged-in="false/true"` to the login/register and logout buttons in `navTabs.isml, header.isml, login.isml, mobileHeader.isml`
3. hide login and register forms in `login.isml`
4. add a script to prevent URL redirection when click login/logout buttons in `sso.js`
5. pass Bolt config to header and login page in `Account.js and Login.js`

Sandbox for reference - https://zzgv-019.dx.commercecloud.salesforce.com/on/demandware.store/Sites-RefArch-Site/en_US/Login-Show

https://github.com/BoltApp/bolt-demandware-managed/assets/104028876/5ef89753-cee7-4eb0-bfb1-7d4f16bb63f8

