### PR TITLE
[WIP] Fix PPC issues

### DIFF
--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -164,7 +164,7 @@ const buildBoltCartObject = function (product) {
                 quantity: quantity,
                 name: productName,
                 image: productImage,
-                options: productOptions
+                options: JSON.stringify(productOptions)
             }
         ]
     };
@@ -210,7 +210,7 @@ var getOptions = function ($productContainer) {
         }).toArray();
 
     return options;
-}
+};
 
 $(document).ready(function () {
     var addToCartBtn = $('button.add-to-cart');
@@ -251,7 +251,6 @@ $(document).ready(function () {
     });
 });
 
-
 // ----------------------------- WIP -----------------------------
 /*
     Problems with the current implementation of `buildBoltCartObject`
@@ -282,7 +281,7 @@ var wipBuildBoltCartObject = function () {
         return childProducts.length ? JSON.stringify(childProducts) : [];
     };
 
-    var getOptions = function ($productContainer) {
+    var wipGetOptions = function ($productContainer) {
         var options = $productContainer
             .find('.product-option')
             .map(function () {
@@ -340,7 +339,7 @@ var wipBuildBoltCartObject = function () {
     console.log(`The form element is ${JSON.stringify(form)}`);
 
     if (!$('.bundle-item').length) {
-        form.options = getOptions($productContainer);
+        form.options = wipGetOptions($productContainer);
     }
 
     return {

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -204,8 +204,8 @@ var getOptions = function ($productContainer) {
             var selectedValueId = $elOption.find('option[value="' + urlValue + '"]')
                 .data('value-id');
             return {
-                optionId: $(this).data('option-id'),
-                selectedValueId: selectedValueId
+                option_id: $(this).data('option-id'),
+                option_value_id: selectedValueId
             };
         }).toArray();
 

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -227,7 +227,7 @@ $(document).ready(function () {
             method: 'GET',
             async: false,
             success: function (data) {
-                if (data !== null && data.hasOwnProperty('product')) {
+                if (data !== null && Object.prototype.hasOwnProperty.call(data, 'product')) {
                     var product = data.product;
                     if (product.available && product.readyToOrder) {
                         var boltCartObject = buildBoltCartObject(product);

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -281,7 +281,7 @@ var wipBuildBoltCartObject = function () {
         return childProducts.length ? JSON.stringify(childProducts) : [];
     };
 
-    var wipGetOptions = function ($productContainer) {
+    var buildOptions = function ($productContainer) {
         var options = $productContainer
             .find('.product-option')
             .map(function () {
@@ -339,7 +339,7 @@ var wipBuildBoltCartObject = function () {
     console.log(`The form element is ${JSON.stringify(form)}`);
 
     if (!$('.bundle-item').length) {
-        form.options = wipGetOptions($productContainer);
+        form.options = buildOptions($productContainer);
     }
 
     return {

--- a/cartridges/int_bolt_sfra/cartridge/templates/default/product/components/boltProductPageButton.isml
+++ b/cartridges/int_bolt_sfra/cartridge/templates/default/product/components/boltProductPageButton.isml
@@ -9,6 +9,7 @@
 
     <input type="hidden" id="sfccBaseVersion" name="sfccBaseVersion" value="${pdict.config.sfccBaseVersion}" />
     <input type="hidden" id="successRedirect" name="successRedirect" value="${URLUtils.url('Order-Confirm')}" />
+    <input type="hidden" class="get-ppc-product-data" value="${URLUtils.url('Product-Variation')}" />
     <!--
         This appears to be included via boltScripts.isml. Double check if this needs to be included here.
         <script id="bolt-connect" src="${boltCdnUrl}/connect.js" data-publishable-key="${boltPublishableKey}"></script>


### PR DESCRIPTION
To fix issues mentioned in [PR 58](https://github.com/BoltApp/bolt-demandware-managed/pull/58)

For issues #1&#2

When product details page has fully loaded, we can check if the add-to-cart button is enabled, then get product data from controller Product-Variation (which is defined in sfcc core) to build Bolt cart object to initiate Bolt PPC button.

For issues #4

Just get the options (such as "Extended Warranty") from product details page and send to Bolt server, then in the Bolt server side, adds a product to the cart with these options, and the cart will include the option price.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204881002002279