### PR TITLE
Reset the session id if invalid

### DIFF
--- a/@types/dw/attrs.d.ts
+++ b/@types/dw/attrs.d.ts
@@ -401,6 +401,16 @@ declare class SitePreferencesCustomAttributes {
    * Bolt Partner Merchant
    */
   boltPartnerMerchant: string;
+
+  /**
+   * Bolt Client ID
+   */
+  boltClientID: string;
+
+  /**
+   * Enable Reset Session ID
+   */
+  boltEnableResetDwsid: boolean;
 }
 /**
  * Custom attributes for ActiveData object.

--- a/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
@@ -7,8 +7,8 @@
 /* eslint-disable no-shadow */
 
 /* API Includes */
-var Site = require("dw/system/Site");
-var Mac = require("dw/crypto/Mac");
+var Site = require('dw/system/Site');
+var Mac = require('dw/crypto/Mac');
 var System = require('dw/system/System');
 var Encoding = require('dw/crypto/Encoding');
 var LocalServiceRegistry = require('dw/svc/LocalServiceRegistry');
@@ -226,10 +226,10 @@ exports.respondError = function (res, errorMessage, statusCode) {
  */
 function jwtServiceParseResponse(_, httpClient) {
     if (httpClient.statusCode === 200 || httpClient.statusCode === 201) {
-        return httpClient.getResponseHeader("Authorization");
+        return httpClient.getResponseHeader('Authorization');
     }
 
-    log.error("Error on http request: " + httpClient.getErrorText());
+    log.error('Error on http request: ' + httpClient.getErrorText());
     return null;
 }
 
@@ -239,16 +239,16 @@ function jwtServiceParseResponse(_, httpClient) {
  * @returns {dw.svc.Service} JWT service
  */
 function getJWTServiceInstance() {
-    return LocalServiceRegistry.createService("bolt.http", {
+    return LocalServiceRegistry.createService('bolt.http', {
         createRequest: function createRequest(service, args) {
             service.setURL(args.endpointURL);
             service.setRequestMethod(args.method);
-            service.addHeader("Content-Type", "application/json");
-            service.addHeader("x-dw-client-id", args.clientID);
-            service.addHeader("Cookie", "dwsid=" + args.dwsid);
+            service.addHeader('Content-Type', 'application/json');
+            service.addHeader('x-dw-client-id', args.clientID);
+            service.addHeader('Cookie', 'dwsid=' + args.dwsid);
             return args.request;
         },
-        parseResponse: jwtServiceParseResponse,
+        parseResponse: jwtServiceParseResponse
     });
 }
 
@@ -261,17 +261,12 @@ exports.checkIfSessionIdValid = function (dwsid) {
     var serviceInstance = getJWTServiceInstance();
     var config = getConfiguration();
     var siteID = Site.current.ID;
-    var endpointURL =
-        "https://" +
-        System.instanceHostname +
-        "/s/" +
-        siteID +
-        "/dw/shop/v21_10/customers/auth";
+    var endpointURL = 'https://' + System.instanceHostname + '/s/' + siteID + '/dw/shop/v21_10/customers/auth';
     var requestBody = JSON.stringify({
-        type: "session",
+        type: 'session',
     });
     var serviceArgs = {
-        method: "post",
+        method: 'post',
         endpointURL: endpointURL,
         clientID: config.boltClientID,
         dwsid: dwsid,

--- a/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
@@ -263,14 +263,14 @@ exports.checkIfSessionIdValid = function (dwsid) {
     var siteID = Site.current.ID;
     var endpointURL = 'https://' + System.instanceHostname + '/s/' + siteID + '/dw/shop/v21_10/customers/auth';
     var requestBody = JSON.stringify({
-        type: 'session',
+        type: 'session'
     });
     var serviceArgs = {
         method: 'post',
         endpointURL: endpointURL,
         clientID: config.boltClientID,
         dwsid: dwsid,
-        request: requestBody,
+        request: requestBody
     };
     var result = serviceInstance.call(serviceArgs);
 

--- a/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/services/utils/httpUtils.js
@@ -7,8 +7,9 @@
 /* eslint-disable no-shadow */
 
 /* API Includes */
-var Site = require('dw/system/Site');
-var Mac = require('dw/crypto/Mac');
+var Site = require("dw/system/Site");
+var Mac = require("dw/crypto/Mac");
+var System = require('dw/system/System');
 var Encoding = require('dw/crypto/Encoding');
 var LocalServiceRegistry = require('dw/svc/LocalServiceRegistry');
 var HttpResult = require('dw/svc/Result');
@@ -186,7 +187,7 @@ function getConfiguration() {
     var boltSigningSecret = site.getCustomPreferenceValue('boltSigningSecret') || '';
     var boltAPIKey = site.getCustomPreferenceValue('boltAPIKey') || '';
     var boltPartnerMerchant = site.getCustomPreferenceValue('boltPartnerMerchant').valueOf() || '';
-
+    var boltClientID = site.getCustomPreferenceValue('boltClientID') || '';
     if (boltAPIKey === '' || boltSigningSecret === '') {
         log.error('Error: Bolt Business Manager configurations are missing.');
     }
@@ -197,7 +198,8 @@ function getConfiguration() {
         boltAPIKey: boltAPIKey,
         boltPartnerMerchant: boltPartnerMerchant,
         boltAPIbaseURL: baseAPIUrl,
-        boltAPIBaseURLV1: baseAPIUrl + '/v1'
+        boltAPIBaseURLV1: baseAPIUrl + '/v1',
+        boltClientID: boltClientID
     };
 }
 
@@ -214,4 +216,72 @@ exports.respondError = function (res, errorMessage, statusCode) {
         status: 'error',
         message: errorMessage
     });
+};
+
+/**
+ * Get the result object of service call
+ * @param {Object} _ - Service Object, unused
+ * @param {Object} httpClient - httpClient Object
+ * @returns {Object} service call result object
+ */
+function jwtServiceParseResponse(_, httpClient) {
+    if (httpClient.statusCode === 200 || httpClient.statusCode === 201) {
+        return httpClient.getResponseHeader("Authorization");
+    }
+
+    log.error("Error on http request: " + httpClient.getErrorText());
+    return null;
+}
+
+/**
+ * Get JWT service instance with headers set
+ *
+ * @returns {dw.svc.Service} JWT service
+ */
+function getJWTServiceInstance() {
+    return LocalServiceRegistry.createService("bolt.http", {
+        createRequest: function createRequest(service, args) {
+            service.setURL(args.endpointURL);
+            service.setRequestMethod(args.method);
+            service.addHeader("Content-Type", "application/json");
+            service.addHeader("x-dw-client-id", args.clientID);
+            service.addHeader("Cookie", "dwsid=" + args.dwsid);
+            return args.request;
+        },
+        parseResponse: jwtServiceParseResponse,
+    });
+}
+
+/**
+ * Check if the session id (dwsid) is valid
+ * @param {string} dwsid - dwsid cookie value
+ * @returns {boolean} false to indicate the session id is expired
+ */
+exports.checkIfSessionIdValid = function (dwsid) {
+    var serviceInstance = getJWTServiceInstance();
+    var config = getConfiguration();
+    var siteID = Site.current.ID;
+    var endpointURL =
+        "https://" +
+        System.instanceHostname +
+        "/s/" +
+        siteID +
+        "/dw/shop/v21_10/customers/auth";
+    var requestBody = JSON.stringify({
+        type: "session",
+    });
+    var serviceArgs = {
+        method: "post",
+        endpointURL: endpointURL,
+        clientID: config.boltClientID,
+        dwsid: dwsid,
+        request: requestBody,
+    };
+    var result = serviceInstance.call(serviceArgs);
+
+    if (result.error === 401) {
+        return false;
+    }
+
+    return true;
 };

--- a/cartridges/int_bolt_core/cartridge/scripts/services/utils/preferences.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/services/utils/preferences.js
@@ -39,7 +39,7 @@ exports.getSitePreferences = function () {
         sfccBaseVersion: getSFCCBaseVersion(),
         boltEnablePPC: Site.getCurrent().getCustomPreferenceValue('boltEnablePPC') || false,
         boltClientID: Site.getCurrent().getCustomPreferenceValue('boltClientID') || '',
-        boltEnableResetDwsid: Site.getCurrent().getCustomPreferenceValue('boltEnableResetDwsid') || false,
+        boltEnableResetDwsid: Site.getCurrent().getCustomPreferenceValue('boltEnableResetDwsid') || false
     };
 };
 

--- a/cartridges/int_bolt_core/cartridge/scripts/services/utils/preferences.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/services/utils/preferences.js
@@ -37,7 +37,9 @@ exports.getSitePreferences = function () {
         boltMultiPublishableKey: boltMultiPublishableKey,
         blockedCharactersList: blockedCharactersList,
         sfccBaseVersion: getSFCCBaseVersion(),
-        boltEnablePPC: Site.getCurrent().getCustomPreferenceValue('boltEnablePPC') || false
+        boltEnablePPC: Site.getCurrent().getCustomPreferenceValue('boltEnablePPC') || false,
+        boltClientID: Site.getCurrent().getCustomPreferenceValue('boltClientID') || '',
+        boltEnableResetDwsid: Site.getCurrent().getCustomPreferenceValue('boltEnableResetDwsid') || false,
     };
 };
 

--- a/cartridges/int_bolt_core/cartridge/scripts/utils/commonUtils.js
+++ b/cartridges/int_bolt_core/cartridge/scripts/utils/commonUtils.js
@@ -69,3 +69,14 @@ exports.getDwsidCookie = function () {
 
     return '';
 };
+
+/**
+ * Delete the session id (dwsid)
+ */
+exports.delDwsidCookie = function () {
+    var Cookie = require('dw/web/Cookie');
+    var sessionCookie = new Cookie('dwsid', '');
+    sessionCookie.setPath('/');
+    sessionCookie.setMaxAge(0);
+    response.addHttpCookie(sessionCookie);
+};

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -31,6 +31,22 @@ var callbacks = {
             redirect.submit();
         }
     },
+    check: function () {
+        var checkSession = $('#boltEnableResetDwsid').val();
+        if (checkSession === 'enable') {
+            var validateSessionUrl = $('.validate-reset-dwsid-url').val();
+            $.ajax({
+                url: validateSessionUrl,
+                method: 'GET',
+                async: false,
+                success: function (data) {
+                    // do nothing
+                }
+            });
+        }
+        
+        return true;
+    },
     onCheckoutStart: function () {
     // This function is called after the checkout form is presented to the user.
     },

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -39,12 +39,11 @@ var callbacks = {
                 url: validateSessionUrl,
                 method: 'GET',
                 async: false,
-                success: function (data) {
+                success: function () {
                     // do nothing
                 }
             });
         }
-        
         return true;
     },
     onCheckoutStart: function () {

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -33,18 +33,32 @@ var callbacks = {
     },
     check: function () {
         var checkSession = $('#boltEnableResetDwsid').val();
+        var checkFlag = true;
         if (checkSession === 'enable') {
             var validateSessionUrl = $('.validate-reset-dwsid-url').val();
             $.ajax({
                 url: validateSessionUrl,
                 method: 'GET',
                 async: false,
-                success: function () {
-                    // do nothing
+                success: function (data) {
+                    if (data !== null && !data.isSessionValid) {
+                        checkFlag = false;
+                        let divBoltErr = document.createElement('div');
+                        let errContent = document.createTextNode('Your session timed out due to inactivity. Reloading page now.');
+                        divBoltErr.appendChild(errContent);
+                        if ($('.bolt-cart-btn').length > 0) {
+                            $('.bolt-cart-btn').append(divBoltErr);
+                        } else if (('.bolt-minicart-btn').length > 0) {
+                            $('.bolt-minicart-btn').append(divBoltErr);
+                        }
+                        setTimeout(function () {
+                            location.reload();
+                        }, 1500); //will call the function after 1.5 secs.
+                    }
                 }
             });
         }
-        return true;
+        return checkFlag;
     },
     onCheckoutStart: function () {
     // This function is called after the checkout form is presented to the user.

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -51,9 +51,7 @@ var callbacks = {
                         } else if (('.bolt-minicart-btn').length > 0) {
                             $('.bolt-minicart-btn').append(divBoltErr);
                         }
-                        setTimeout(function () {
-                            location.reload();
-                        }, 1500); //will call the function after 1.5 secs.
+                        setTimeout(function () {window.location.reload();}, 1500);
                     }
                 }
             });

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/bolt.js
@@ -51,7 +51,7 @@ var callbacks = {
                         } else if (('.bolt-minicart-btn').length > 0) {
                             $('.bolt-minicart-btn').append(divBoltErr);
                         }
-                        setTimeout(function () {window.location.reload();}, 1500);
+                        setTimeout(function () { window.location.reload(); }, 1500);
                     }
                 }
             });

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -67,9 +67,7 @@ var callbacks = {
                         let errContent = document.createTextNode('Your session timed out due to inactivity. Reloading page now.');
                         divBoltErr.appendChild(errContent);
                         $('#product-page-checkout-wrapper').append(divBoltErr);
-                        setTimeout(function () {
-                            location.reload();
-                        }, 1500); //will call the function after 1.5 secs.
+                        setTimeout(function () {window.location.reload();}, 1500);
                     }
                 }
             });

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -14,9 +14,27 @@ var callbacks = {
     check: function () {
         console.log('Inside check function');
         if (ppcCart) {
+            var checkSession = $('#boltEnableResetDwsid').val();
+            if (checkSession === 'enable') {
+                var validateSessionUrl = $('.validate-reset-dwsid-url').val();
+                $.ajax({
+                    url: validateSessionUrl,
+                    method: 'GET',
+                    async: false,
+                    success: function (data) {
+                        if (data !== null && !data.isSessionValid) {
+                            ppcCart = false;
+                            let divBoltErr = document.createElement('div');
+                            let errContent = document.createTextNode('Your session timed out due to inactivity. Reloading page now.');
+                            divBoltErr.appendChild(errContent);
+                            $('#product-page-checkout-wrapper').append(divBoltErr);
+                            setTimeout(function () { window.location.reload(); }, 1500);
+                        }
+                    }
+                });
+            }
             return ppcCart;
         }
-
         if (ppcButtonVisible) {
             // Display an error message to the user.
             console.error('Bolt ppc cart is invalid');
@@ -50,29 +68,6 @@ var callbacks = {
 
             redirect.submit();
         }
-    },
-    check: function () {
-        var checkSession = $('#boltEnableResetDwsid').val();
-        var checkFlag = true;
-        if (checkSession === 'enable') {
-            var validateSessionUrl = $('.validate-reset-dwsid-url').val();
-            $.ajax({
-                url: validateSessionUrl,
-                method: 'GET',
-                async: false,
-                success: function (data) {
-                    if (data !== null && !data.isSessionValid) {
-                        checkFlag = false;
-                        let divBoltErr = document.createElement('div');
-                        let errContent = document.createTextNode('Your session timed out due to inactivity. Reloading page now.');
-                        divBoltErr.appendChild(errContent);
-                        $('#product-page-checkout-wrapper').append(divBoltErr);
-                        setTimeout(function () {window.location.reload();}, 1500);
-                    }
-                }
-            });
-        }
-        return checkFlag;
     },
     onCheckoutStart: function () {
         // This function is called after the checkout form is presented to the user.

--- a/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
+++ b/cartridges/int_bolt_sfra/cartridge/client/default/js/boltProductPageButton.js
@@ -51,6 +51,31 @@ var callbacks = {
             redirect.submit();
         }
     },
+    check: function () {
+        var checkSession = $('#boltEnableResetDwsid').val();
+        var checkFlag = true;
+        if (checkSession === 'enable') {
+            var validateSessionUrl = $('.validate-reset-dwsid-url').val();
+            $.ajax({
+                url: validateSessionUrl,
+                method: 'GET',
+                async: false,
+                success: function (data) {
+                    if (data !== null && !data.isSessionValid) {
+                        checkFlag = false;
+                        let divBoltErr = document.createElement('div');
+                        let errContent = document.createTextNode('Your session timed out due to inactivity. Reloading page now.');
+                        divBoltErr.appendChild(errContent);
+                        $('#product-page-checkout-wrapper').append(divBoltErr);
+                        setTimeout(function () {
+                            location.reload();
+                        }, 1500); //will call the function after 1.5 secs.
+                    }
+                }
+            });
+        }
+        return checkFlag;
+    },
     onCheckoutStart: function () {
         // This function is called after the checkout form is presented to the user.
     },

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
@@ -4,11 +4,13 @@ var server = require('server');
 
 /* API Includes */
 var BasketMgr = require('dw/order/BasketMgr');
+var URLUtils = require('dw/web/URLUtils');
 
 /* Script Modules */
 var BoltPreferences = require('int_bolt_core/cartridge/scripts/services/utils/preferences');
 var UserSignature = require('int_bolt_core/cartridge/scripts/cart/userSignature');
 var commonUtils = require('int_bolt_core/cartridge/scripts/utils/commonUtils');
+var BoltHttpUtils = require('int_bolt_core/cartridge/scripts/services/utils/httpUtils');
 
 /**
  *  Get basket ID since SFCC frontend doesn't expose it by default.
@@ -37,5 +39,27 @@ server.get('GetOrderReference', server.middleware.https, function (req, res, nex
     });
     next();
 });
+
+/**
+ *  Validate the session id (dwsid) and delete the invalid one, 
+ *  so that the session id can be reset after refreshing page.
+ */
+server.get(
+    "ValidateResetSfccSession",
+    server.middleware.https,
+    function (req, res, next) {
+        var dwsid = commonUtils.getDwsidCookie();
+        var isSessionValid = BoltHttpUtils.checkIfSessionIdValid(dwsid);
+        var redirectUrl = "";
+        if (!isSessionValid) {
+            commonUtils.delDwsidCookie();
+        }
+        res.setStatusCode(200);
+        res.json({
+          rev: isSessionValid,
+        });
+        next();
+    }
+);
 
 module.exports = server.exports();

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
@@ -53,7 +53,7 @@ server.get(
         }
         res.setStatusCode(200);
         res.json({
-          rev: isSessionValid
+            rev: isSessionValid
         });
         next();
     }

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
@@ -4,7 +4,6 @@ var server = require('server');
 
 /* API Includes */
 var BasketMgr = require('dw/order/BasketMgr');
-var URLUtils = require('dw/web/URLUtils');
 
 /* Script Modules */
 var BoltPreferences = require('int_bolt_core/cartridge/scripts/services/utils/preferences');
@@ -41,22 +40,20 @@ server.get('GetOrderReference', server.middleware.https, function (req, res, nex
 });
 
 /**
- *  Validate the session id (dwsid) and delete the invalid one, 
- *  so that the session id can be reset after refreshing page.
+ *  Validate the session id (dwsid) and delete the invalid one, so that the session id can be reset after refreshing page.
  */
 server.get(
-    "ValidateResetSfccSession",
+    'ValidateResetSfccSession',
     server.middleware.https,
     function (req, res, next) {
         var dwsid = commonUtils.getDwsidCookie();
         var isSessionValid = BoltHttpUtils.checkIfSessionIdValid(dwsid);
-        var redirectUrl = "";
         if (!isSessionValid) {
             commonUtils.delDwsidCookie();
         }
         res.setStatusCode(200);
         res.json({
-          rev: isSessionValid,
+          rev: isSessionValid
         });
         next();
     }

--- a/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
+++ b/cartridges/int_bolt_sfra/cartridge/controllers/Bolt.js
@@ -53,7 +53,7 @@ server.get(
         }
         res.setStatusCode(200);
         res.json({
-            rev: isSessionValid
+            isSessionValid: isSessionValid
         });
         next();
     }

--- a/cartridges/int_bolt_sfra/cartridge/templates/default/cart/boltButton.isml
+++ b/cartridges/int_bolt_sfra/cartridge/templates/default/cart/boltButton.isml
@@ -1,6 +1,8 @@
 <div class="bolt-${pdict.component}">
     <isif condition="${pdict.config.boltEnable && (pdict.isMiniCart || (pdict.items.length !== 0 || pdict.giftCertificateItems.length !== 0))}">
         <input type="hidden" class="create-bolt-order-url" value="${URLUtils.https('Bolt-GetOrderReference')}" />
+        <input type="hidden" class="validate-reset-dwsid-url" value="${URLUtils.https('Bolt-ValidateResetSfccSession')}" />
+        <input type="hidden" id="boltEnableResetDwsid" name="boltEnableResetDwsid" value="${pdict.config.boltEnableResetDwsid == true ? 'enable' : 'disable'}" />
         <input type="hidden" id="sfccBaseVersion" name="sfccBaseVersion" value="${pdict.config.sfccBaseVersion}" />
         <input type="hidden" id="successRedirect" name="successRedirect" value="${URLUtils.url('Order-Confirm')}" />
 

--- a/cartridges/int_bolt_sfra/cartridge/templates/default/product/components/boltProductPageButton.isml
+++ b/cartridges/int_bolt_sfra/cartridge/templates/default/product/components/boltProductPageButton.isml
@@ -10,6 +10,8 @@
     <input type="hidden" id="sfccBaseVersion" name="sfccBaseVersion" value="${pdict.config.sfccBaseVersion}" />
     <input type="hidden" id="successRedirect" name="successRedirect" value="${URLUtils.url('Order-Confirm')}" />
     <input type="hidden" class="get-ppc-product-data" value="${URLUtils.url('Product-Variation')}" />
+    <input type="hidden" class="validate-reset-dwsid-url" value="${URLUtils.https('Bolt-ValidateResetSfccSession')}" />
+    <input type="hidden" id="boltEnableResetDwsid" name="boltEnableResetDwsid" value="${pdict.config.boltEnableResetDwsid == true ? 'enable' : 'disable'}" />
     <!--
         This appears to be included via boltScripts.isml. Double check if this needs to be included here.
         <script id="bolt-connect" src="${boltCdnUrl}/connect.js" data-publishable-key="${boltPublishableKey}"></script>

--- a/metadata/bolt-meta-import/meta/system-objecttype-extensions.xml
+++ b/metadata/bolt-meta-import/meta/system-objecttype-extensions.xml
@@ -617,6 +617,20 @@
         <regex>^([0-9]+\.)+[0-9]+$</regex>
         <default-value>5.0.0</default-value>
       </attribute-definition>
+      <attribute-definition attribute-id="boltClientID">
+        <display-name xml:lang="x-default">Bolt Client ID</display-name>
+        <type>string</type>
+        <mandatory-flag>false</mandatory-flag>
+        <externally-managed-flag>false</externally-managed-flag>
+        <min-length>0</min-length>
+      </attribute-definition>
+      <attribute-definition attribute-id="boltEnableResetDwsid">
+        <display-name xml:lang="x-default">Enable Reset Session ID</display-name>
+        <type>boolean</type>
+        <mandatory-flag>false</mandatory-flag>
+        <externally-managed-flag>false</externally-managed-flag>
+        <default-value>false</default-value>
+      </attribute-definition>
     </custom-attribute-definitions>
 
     <group-definitions>
@@ -635,6 +649,8 @@
         <attribute attribute-id="boltPartnerMerchant"/>
         <attribute attribute-id="boltMerchantDivisionID"/>
         <attribute attribute-id="sfccBaseVersion"/>
+        <attribute attribute-id="boltClientID"/>
+        <attribute attribute-id="boltEnableResetDwsid"/>
       </attribute-group>
       <attribute-group group-id="BoltPluginSetting">
         <display-name xml:lang="x-default">Bolt Plugins Setting</display-name>


### PR DESCRIPTION
As we can not resolve the session failed issue for generating JWT from source, we consider to fix it in the plugin.

With this PR:
1. Add two new fields "Bolt Client ID" and "Enable Reset Session ID" under the "Bolt Payment Setting - Managed Checkout" group, then the "Enable Reset Session ID" is used to enable/disable the feature to reset session id, and the "Bolt Client ID" is used to call the OCAPI customers/auth from controller to verify the session.
2. Add utils functions to call the OCAPI customers/auth from controller to verify the session.
3. Add a new controller "ValidateResetSfccSession" to validate the session id, if it is invalid, we delete this httponly cookie from server side, so that the session id can be reset after refreshing page.
4. Then in the client side, when the shopper click the Bolt checkout button, the "check" callback is triggered, and if "Enable Reset Session ID" is set to "Yes", the controller "ValidateResetSfccSession" would be called to validate session and reset it if needed. The Bolt modal will still be opened to notify the shopper that the session is expired and he needs to refresh the page. After he refresh the page, a new session id would be generated.

https://app.devrev.ai/bolt-inc/works/ISS-1300